### PR TITLE
Switch from server to client and make connections asynch

### DIFF
--- a/src/libstrongswan/plugins/pqsdk/pqsdkd/Makefile.am
+++ b/src/libstrongswan/plugins/pqsdk/pqsdkd/Makefile.am
@@ -11,8 +11,9 @@ plugin_LTLIBRARIES = libstrongswan-pqsdk-pqsdkd.la
 endif
 
 libstrongswan_pqsdk_pqsdkd_la_SOURCES = \
-	pqsdkd_plugin.c						\
-	kem.c
+	comm.c                              \
+	kem.c								\
+	pqsdkd_plugin.c
 
 libstrongswan_pqsdk_pqsdkd_la_LDFLAGS = \
 	-L$(PQSDK_LIB_DIR) 					\

--- a/src/libstrongswan/plugins/pqsdk/pqsdkd/comm.c
+++ b/src/libstrongswan/plugins/pqsdk/pqsdkd/comm.c
@@ -1,0 +1,96 @@
+#include <utils/debug.h>
+#include <library.h>
+
+#include "comm.h"
+
+/**
+ * Mutex synchronizing access to the connection_list.
+ */
+mutex_t *connection_list_mutex = NULL;
+
+/**
+ * List containing PQSDKd connection contexts.
+ */
+linked_list_t *connection_list = NULL;
+
+static inline comm_t* comm_get_by_id_unlocked(linked_list_t *l, int id) {
+	enumerator_t *it;
+	comm_t *el;
+
+	it = l->create_enumerator(l);
+	while(it->enumerate(it, &el)) {
+		if (el->id == id) {
+			it->destroy(it);
+			return el;
+		}
+	}
+	it->destroy(it);
+	return NULL;
+}
+
+bool comm_add(linked_list_t *l, comm_t *c) {
+	comm_t *el;
+	connection_list_mutex->lock(connection_list_mutex);
+	el = comm_get_by_id_unlocked(l, c->id);
+	if (!el) {
+		c->is_used = FALSE;
+		l->insert_last(l, c);
+	}
+	connection_list_mutex->unlock(connection_list_mutex);
+	return el?FALSE:TRUE;
+}
+
+comm_t* comm_lock_next(linked_list_t *l) {
+	comm_t *el = NULL, *eltmp;
+	enumerator_t *it;
+
+	connection_list_mutex->lock(connection_list_mutex);
+	it = l->create_enumerator(l);
+
+	while(it->enumerate(it, &el)) {
+		if (!el->is_used) {
+			el->is_used = TRUE;
+			break;
+		}
+		el = NULL;
+	}
+	it->destroy(it);
+	connection_list_mutex->unlock(connection_list_mutex);
+	return el;
+}
+
+void comm_unlock(linked_list_t *l, int id) {
+	comm_t *el = NULL;
+
+	connection_list_mutex->lock(connection_list_mutex);
+	if ((el = comm_get_by_id_unlocked(l, id))) {
+		el->is_used = FALSE;
+	}
+	connection_list_mutex->unlock(connection_list_mutex);
+}
+
+comm_t* comm_get_by_id(linked_list_t *l, int id) {
+	comm_t *el = NULL;
+	connection_list_mutex->lock(connection_list_mutex);
+	el = comm_get_by_id_unlocked(l, id);
+	connection_list_mutex->unlock(connection_list_mutex);
+	return el;
+}
+
+void comm_clean_list(linked_list_t *l) {
+	comm_t *el;
+
+	if (!l) {
+		return;
+	}
+
+	connection_list_mutex->lock(connection_list_mutex);
+	// close connections
+	while (l->remove_last(l, (void**)&el) == SUCCESS) {
+		if (el->stream) {
+			el->stream->destroy(el->stream);
+		}
+		free(el);
+	}
+	connection_list_mutex->unlock(connection_list_mutex);
+}

--- a/src/libstrongswan/plugins/pqsdk/pqsdkd/comm.c
+++ b/src/libstrongswan/plugins/pqsdk/pqsdkd/comm.c
@@ -59,6 +59,20 @@ comm_t* comm_lock_next(linked_list_t *l) {
 	return el;
 }
 
+comm_t* comm_lock_by_id(linked_list_t *l, int id) {
+	comm_t *ret = NULL;
+	comm_t *el = NULL;
+	connection_list_mutex->lock(connection_list_mutex);
+	if ((el = comm_get_by_id_unlocked(l, id))) {
+		if (!el->is_used) {
+			el->is_used = TRUE;
+			ret = el;
+		}
+	}
+	connection_list_mutex->unlock(connection_list_mutex);
+	return ret;
+}
+
 void comm_unlock(linked_list_t *l, int id) {
 	comm_t *el = NULL;
 

--- a/src/libstrongswan/plugins/pqsdk/pqsdkd/comm.h
+++ b/src/libstrongswan/plugins/pqsdk/pqsdkd/comm.h
@@ -30,6 +30,17 @@ typedef struct comm_t {
    * Indicates wether connection is currently in use.
    */
   bool is_used;
+
+  /**
+   * Whether try_connect callback should close the stream
+   * before calling connect()
+   */
+  bool reconnect;
+
+  /**
+   * Amount of ms to wait before trying to reconnect to PQSDKd
+   */
+  int reconnect_timeout;
 } comm_t;
 
 /**
@@ -60,11 +71,22 @@ comm_t *comm_get_by_id(linked_list_t *comm_list, int id);
  *
  * @param comm_list		List of usable communication
  *						contexts.
- * @param id 			Unique ID of communitaction context.
  * @return				Communication context or NULL if non
  *available.
  */
 comm_t *comm_lock_next(linked_list_t *comm_list);
+
+/**
+ * Locks and returns communication context assigned
+ * to "id". The context must be unused.
+ *
+ * @param comm_list		List of usable communication
+ *						contexts.
+ * @param id 			Unique ID of communitaction context.
+ * @return				Communication context or NULL if not
+ *available.
+ */
+comm_t *comm_lock_by_id(linked_list_t *comm_list, int fd);
 
 /**
  * Mark communication context as free to use.

--- a/src/libstrongswan/plugins/pqsdk/pqsdkd/comm.h
+++ b/src/libstrongswan/plugins/pqsdk/pqsdkd/comm.h
@@ -1,0 +1,85 @@
+#ifndef PQSDKD_COMM_H_
+#define PQSDKD_COMM_H_
+
+#include <collections/linked_list.h>
+#include <library.h>
+#include <threading/mutex.h>
+
+/**
+ * PQSDKd communication context. Stores file descriptor
+ * for listener and the one returned by accept().
+ */
+typedef struct comm_t {
+
+  /**
+   * Communitaction context identifier.
+   */
+  size_t id;
+
+  /**
+   * Path to PQSDKd socket, read from configuration file.
+   */
+  char *socket_path;
+
+  /**
+   * Stream object
+   */
+  stream_t *stream;
+
+  /**
+   * Indicates wether connection is currently in use.
+   */
+  bool is_used;
+} comm_t;
+
+/**
+ * Adds communication context to the list.
+ *
+ * @param comm_list		List of usable communication
+ *						contexts.
+ * @param id 			Unique ID of communitaction context.
+ * @param comm			Usable communication context.
+ * @return				TRUE if added, FALSE if comm with ID
+ *already exists
+ */
+bool comm_add(linked_list_t *comm_list, comm_t *comm);
+
+/**
+ * Finds communication context by ID.
+ *
+ * @param comm_list		List of usable communication
+ *						contexts.
+ * @param id 			Unique ID of communitaction context.
+ * @return				Communication context or NULL if not
+ *found.
+ */
+comm_t *comm_get_by_id(linked_list_t *comm_list, int id);
+
+/**
+ * Locks and returns next available communication context.
+ *
+ * @param comm_list		List of usable communication
+ *						contexts.
+ * @param id 			Unique ID of communitaction context.
+ * @return				Communication context or NULL if non
+ *available.
+ */
+comm_t *comm_lock_next(linked_list_t *comm_list);
+
+/**
+ * Mark communication context as free to use.
+ *
+ * @param comm_list		List of usable communication
+ *						contexts.
+ * @param id 			Unique ID of communitaction context.
+ */
+void comm_unlock(linked_list_t *comm_list, int id);
+
+/**
+ * Closes all connections and removes all communication contexts.
+ *
+ * @param l 	List of communication contexts.
+ */
+void comm_clean_list(linked_list_t *l);
+
+#endif // PQSDKD_COMM_H_

--- a/src/libstrongswan/plugins/pqsdk/pqsdkd/kem.c
+++ b/src/libstrongswan/plugins/pqsdk/pqsdkd/kem.c
@@ -13,36 +13,89 @@
  * for more details.
  */
 
+#include <assert.h>
+#include <errno.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include <crypto/key_exchange.h>
+#include <threading/condvar.h>
+#include <threading/mutex.h>
 #include <library.h>
 #include "kem.h"
 #include "pq_message_lib.h"
 #include "pqsdkd_plugin.h"
 #include "comm.h"
 
+#include "processing/jobs/callback_job.h"
+
 #define CHECK_NZ(exp) \
 	do { \
 		if (!(exp)) { \
-			DBG1(DBG_LIB, "NULL pointer: %s\n", #exp); \
+			DBG1(DBG_LIB, "%s:%d NULL pointer: %s\n", __FILE__, __LINE__, #exp); \
 			goto end; \
 		} \
 	} while (0)
 
 typedef struct private_pqsdkd_kem_t private_pqsdkd_kem_t;
 
-// internal state used for indicating initiator/responder side of IKE
+/** Internal state used for indicating initiator/responder side of IKE */
 typedef enum {
-	// KEM created
+	/** KEM created */
 	ACTION_CREATE =  1 << 0,
-	// peer public key set
+	/** peer public key set */
 	ACTION_PUB_SET = 1 << 1,
-	// public key provided to the framework
+	/** public key provided to the framework */
 	ACTION_PUB_GET = 1 << 2,
 } ex_action_t;
+
+/** Flags indicating communication and data exchange state. */
+typedef enum {
+	// No action to be done
+	EX_NONE	       = 0,
+	// Data will be sent to PQSDKd
+	EX_WANTS_WRITE = 1 << 0,
+	// Expects to receive data from PQSDKd
+	EX_WANTS_READ  = 1 << 1,
+	// Must handle disconnection from PQSDKd
+	EX_DISCONNECT  = 1 << 2,
+	// More data exepcted. Keep on_write/on_read callback registered
+	EX_KEEP        = 1 << 3,
+	// Data exchange done. Unregister on_read/on_write callback.
+	EX_UNREGISTER  = 1 << 4,
+	// Communication function starts to wait for a signal from
+	// on_read/on_write threads.
+	EX_CAN_SIGNAL  = 1 << 5,
+} ex_status_t;
+
+/** Communication context between plugin and PQSDKd */
+typedef struct pqsdkd_ctx_t {
+
+	/** Condition variable signals message exchange is over */
+	condvar_t *ex_cond;
+	/** Mutex used for request/response synchronization*/
+	mutex_t *ex_lock;
+	/** Stores poitner to the request. Used by on_write */
+	chunk_t req;
+	/** Stores poitner to the request. Used by on_read */
+	chunk_t rsp;
+	/** Flags indicating operation state. */
+	ex_status_t flags;
+	/**
+	 * Max amount of time read and write operation is allowed
+	 * to take before ex_cond times out.
+	 */
+	int msg_ex_to;
+	/** Number of bytes send or recived till now */
+	size_t bytes_processed;
+	/**
+	 * Pointer to the communication context. Used by diconnect
+	 * funciton.
+	 */
+	comm_t *comm;
+
+} pqsdkd_ctx_t;
 
 typedef struct private_pqsdkd_kem_t {
 	/**
@@ -69,8 +122,7 @@ typedef struct private_pqsdkd_kem_t {
 	/**
 	* Communication context PQSDK:PQSDKD.
 	*/
-	struct comm_t *comm;
-
+	comm_t *comm;
 	/**
 	 * Pre-allocated buffer for request header.
 	 */
@@ -80,6 +132,11 @@ typedef struct private_pqsdkd_kem_t {
 	 * Pre-allocated buffer for response header.
 	 */
 	chunk_t header_rsp;
+
+	/**
+	 * Holds data needed for message exchange with PQSDKd.
+	 */
+	pqsdkd_ctx_t pqsdkd_ctx;
 
 	/**
 	 * Pointer to the PQSDKd connection list
@@ -100,6 +157,11 @@ static bool is_responder(private_pqsdkd_kem_t *ka, ex_action_t action) {
 	return ka->state == (ACTION_CREATE | ACTION_PUB_SET);
 }
 
+// Returns true if "flag" is set in the bitset "bits".
+static inline bool is_set(unsigned int bits, unsigned int flag) {
+	return (bits & flag) == flag;
+}
+
 /**
  *  Returns 0 on failure, otherwise data_len to read
  *  from the req socket.
@@ -107,30 +169,207 @@ static bool is_responder(private_pqsdkd_kem_t *ka, ex_action_t action) {
 static int get_data_len(chunk_t header_rsp) {
 	ResponseHeader rsp = {0};
 	if (deserialize_response_header(header_rsp.ptr, &rsp)) {
-		DBG1(DBG_LIB, "keygen: can't deserialize\n");
+		DBG1(DBG_LIB, "keygen: can't deserialize");
 		return 0;
 	}
 
 	if (rsp.success) {
-		DBG1(DBG_LIB, "keygen: can't deserialize\n");
+		DBG1(DBG_LIB, "keygen: wrong response from PQSDKd");
 		return 0;
 	}
 	return rsp.data_len;
 }
 
+// Handles result received from do_write()/do_read()
+static bool handle_result(ex_status_t status, pqsdkd_ctx_t *ctx) {
+	switch(status) {
+		case EX_KEEP:
+			return TRUE;
+		case EX_UNREGISTER:
+			return FALSE;
+		case EX_DISCONNECT:
+			ctx->ex_lock->lock(ctx->ex_lock);
+			ctx->flags = EX_NONE | EX_CAN_SIGNAL;
+			ctx->ex_lock->unlock(ctx->ex_lock);
+
+			ctx->comm->reconnect = true;
+			ctx->ex_cond->signal(ctx->ex_cond);
+			lib->processor->queue_job(lib->processor,
+				(job_t*)callback_job_create_with_prio((callback_job_cb_t)try_connect,
+					ctx->comm, NULL, (callback_job_cancel_t)return_false, JOB_PRIO_HIGH));
+			return FALSE;
+		default:
+			DBG0(DBG_LIB, "unhandled event occured");
+			/**
+			 * Should never happen. Unregister callback,
+			 * communicate() will generate an error.
+			 */
+			return FALSE;
+	}
+}
+
+static ex_status_t do_write(pqsdkd_ctx_t *ctx, stream_t *stream) {
+	ssize_t len;
+	while (ctx->req.len > ctx->bytes_processed) {
+		len = stream->write(stream,
+			ctx->req.ptr + ctx->bytes_processed,
+			ctx->req.len - ctx->bytes_processed,
+			FALSE);
+
+		if (len == 0) {
+			DBG1(DBG_LIB, "pqsdkd: server disconnected: %s", strerror(errno));
+			return EX_DISCONNECT;
+		}
+
+		if (len < 0) {
+			if (errno == EWOULDBLOCK) {
+				return EX_KEEP;
+			}
+            DBG1(DBG_LIB, "pqsdkd: write error: %s", strerror(errno));
+			return EX_DISCONNECT;
+		}
+		ctx->bytes_processed += (size_t)len;
+	}
+
+	return EX_UNREGISTER;
+}
+
+/**
+ * Process responses from PQSDKd
+ */
+CALLBACK(on_write, bool, pqsdkd_ctx_t *ctx, stream_t *stream) {
+	bool wants_read;
+	ex_status_t ret = EX_UNREGISTER;
+
+	ctx->ex_lock->lock(ctx->ex_lock);
+	if (!is_set(ctx->flags, EX_CAN_SIGNAL)) {
+		ctx->ex_lock->unlock(ctx->ex_lock);
+		return TRUE;
+	}
+
+	if (is_set(ctx->flags, EX_WANTS_WRITE)) {
+		ret = do_write(ctx, stream);
+		if (ret == EX_UNREGISTER) {
+			ctx->flags &= ~EX_WANTS_WRITE;
+			ctx->bytes_processed = 0;
+		}
+	}
+	wants_read = is_set(ctx->flags, EX_WANTS_READ);
+	ctx->ex_lock->unlock(ctx->ex_lock);
+
+	// Don't signal if waiting for response
+	if ((ret == EX_UNREGISTER) && !wants_read) {
+		ctx->ex_cond->signal(ctx->ex_cond);
+	}
+	return handle_result(ret, ctx);
+}
+
+static ex_status_t do_read(pqsdkd_ctx_t *ctx, stream_t *stream) {
+	ssize_t len;
+	while (ctx->rsp.len > ctx->bytes_processed) {
+		len = stream->read(stream,
+			ctx->rsp.ptr + ctx->bytes_processed,
+			ctx->rsp.len - ctx->bytes_processed,
+			FALSE);
+
+		if (len == 0) {
+			DBG1(DBG_LIB, "pqsdkd: server disconnected: %s", strerror(errno));
+			return EX_DISCONNECT;
+		}
+
+		if (len < 0) {
+			if (errno == EWOULDBLOCK) {
+				return EX_KEEP;
+			}
+			DBG1(DBG_LIB, "pqsdkd: read error: %s", strerror(errno));
+			return EX_DISCONNECT;
+		}
+		ctx->bytes_processed += len;
+	}
+	return EX_UNREGISTER;
+}
+
+CALLBACK(on_read, bool, pqsdkd_ctx_t *ctx, stream_t *stream) {
+	bool write_done;
+	ex_status_t ret = EX_UNREGISTER;
+
+	ctx->ex_lock->lock(ctx->ex_lock);
+	if (!is_set(ctx->flags, EX_CAN_SIGNAL)) {
+		ctx->ex_lock->unlock(ctx->ex_lock);
+		return TRUE;
+	}
+
+	write_done = !is_set(ctx->flags, EX_WANTS_WRITE);
+
+	// Don't read until write is finished
+	if (is_set(ctx->flags, EX_WANTS_READ) && write_done) {
+		ret = do_read(ctx, stream);
+		if (ret == EX_UNREGISTER) {
+			ctx->flags &= ~EX_WANTS_READ;
+			ctx->bytes_processed = 0;
+		}
+	}
+
+	ctx->ex_lock->unlock(ctx->ex_lock);
+	if (ret == EX_UNREGISTER) {
+		ctx->ex_cond->signal(ctx->ex_cond);
+	}
+	return handle_result(ret, ctx);
+}
+
 /**
  * Send req.len bytes to the c.req and read rsp.len just after.
- * This function will block.
+ * Returns FALSE if communication error occured.
  */
-static int exchng(chunk_t rsp, const struct comm_t *c, const chunk_t req) {
-	if (!c->stream->write_all(c->stream, req.ptr, req.len)) {
-		return FALSE;
-	}
-	if (!c->stream->read_all(c->stream, rsp.ptr, rsp.len)) {
+static bool communicate(chunk_t rsp, const chunk_t req,
+	stream_t *stream, pqsdkd_ctx_t *ctx) {
+
+	bool ret;
+
+	if (!stream) {
+		DBG1(DBG_LIB, "Connection not available: scheduling reconnect.");
+		lib->processor->queue_job(lib->processor,
+			(job_t*)callback_job_create_with_prio((callback_job_cb_t)try_connect,
+				ctx->comm, NULL, (callback_job_cancel_t)return_false, JOB_PRIO_HIGH));
 		return FALSE;
 	}
 
-	return TRUE;
+	ctx->bytes_processed = 0;
+	ctx->flags = EX_NONE;
+	if (req.len) ctx->flags |= EX_WANTS_WRITE;
+	if (rsp.len) ctx->flags |= EX_WANTS_READ;
+	if (ctx->flags == EX_NONE) return TRUE;
+
+	if (is_set(ctx->flags, EX_WANTS_WRITE)) {
+		ctx->req = req;
+		stream->on_write(stream, on_write, ctx);
+	}
+
+	if (is_set(ctx->flags, EX_WANTS_READ)) {
+		ctx->rsp = rsp;
+		stream->on_read(stream, on_read, ctx);
+	}
+
+	ctx->ex_lock->lock(ctx->ex_lock);
+	/**
+	 * Both threads check if EX_CAN_SIGNAL is set before starting
+	 * to send/receive data. Not having such a flag could cause
+	 * a deadlock, because thread executing on_read/on_write could
+	 * signal before communicate() calls timed_wait(). Hence the goal
+	 * of this flag is to make sure that singal() is called AFTER
+	 * timed_wait() is called.  The other way to avoid deadlock is to
+	 * lock the ex_lock, before calling on_write/on_read, unfortunatelly
+	 * in this causes another deadlock as on_write() may be executed
+	 * before ex_lock is unlocked.
+	 */
+	ctx->flags |= EX_CAN_SIGNAL;
+	ret = ctx->ex_cond->timed_wait(ctx->ex_cond, ctx->ex_lock, ctx->msg_ex_to);
+	ctx->ex_lock->unlock(ctx->ex_lock);
+
+	if (ret) {
+		DBG1(DBG_LIB, "Communication timed out.");
+	}
+	return !ret;
 }
 
 METHOD(key_exchange_t, get_method, key_exchange_method_t,
@@ -149,7 +388,17 @@ METHOD(key_exchange_t, destroy, void,
 	if (this->comm) {
 		comm_unlock(this->connection_list, this->comm->id);
 	}
+
+	// unregister on_read and on_write
+	if (this->comm->stream) {
+		this->comm->stream->on_read(this->comm->stream, NULL, NULL);
+		this->comm->stream->on_write(this->comm->stream, NULL, NULL);
+	}
 	this->comm = NULL;
+	this->pqsdkd_ctx.ex_cond->destroy(this->pqsdkd_ctx.ex_cond);
+	this->pqsdkd_ctx.ex_lock->unlock(this->pqsdkd_ctx.ex_lock);
+	this->pqsdkd_ctx.ex_lock->destroy(this->pqsdkd_ctx.ex_lock);
+	this->pqsdkd_ctx.comm = NULL;
 	free(this);
 }
 
@@ -184,7 +433,8 @@ METHOD(key_exchange_t, get_public_key, bool,
 		CHECK_NZ(!serialize_request_header(this->header_req.ptr,
 			this->header_req.len, 0, 0, this->pqsdkd_meth_id, KeypairGeneration));
 
-		CHECK_NZ(exchng(this->header_rsp, this->comm, this->header_req));
+		CHECK_NZ(communicate(this->header_rsp, this->header_req,
+			this->comm->stream, &this->pqsdkd_ctx));
 		sz = get_data_len(this->header_rsp);
 		CHECK_NZ(sz);
 
@@ -192,7 +442,8 @@ METHOD(key_exchange_t, get_public_key, bool,
 		ch = chunk_alloc(sz);
 		CHECK_NZ(ch.ptr);
 
-		CHECK_NZ(exchng(ch, this->comm, chunk_empty));
+		CHECK_NZ(communicate(ch, chunk_empty, this->comm->stream,
+			&this->pqsdkd_ctx));
 		CHECK_NZ(!destructure_two_entries(ch.ptr, ch.len, &sksz, &pksz,
 			(const unsigned char**)&sk, (const unsigned char**)&pk));
 		this->public.pk = chunk_clone(chunk_create(pk, pksz));
@@ -230,15 +481,19 @@ METHOD(key_exchange_t, set_public_key, bool,
 			this->header_req.len, 0, value.len,
 			this->pqsdkd_meth_id, Encapsulation));
 
-		CHECK_NZ(exchng(chunk_empty, this->comm, this->header_req));
-		CHECK_NZ(exchng(this->header_rsp, this->comm, value));
+		CHECK_NZ(communicate(chunk_empty, this->header_req,
+			this->comm->stream,	&this->pqsdkd_ctx));
+
+		CHECK_NZ(communicate(this->header_rsp, value, this->comm->stream,
+			&this->pqsdkd_ctx));
 		sz = get_data_len(this->header_rsp);
 		CHECK_NZ(sz);
 
 		ch = chunk_alloc(sz);
 		CHECK_NZ(ch.ptr);
 
-		CHECK_NZ(exchng(ch, this->comm, chunk_empty));
+		CHECK_NZ(communicate(ch, chunk_empty, this->comm->stream,
+			&this->pqsdkd_ctx));
 		CHECK_NZ(!destructure_two_entries(ch.ptr, ch.len, &sssz, &ctsz,
 			(const unsigned char**)&ss, (const unsigned char**)&ct));
 
@@ -255,8 +510,10 @@ METHOD(key_exchange_t, set_public_key, bool,
 
 		structure_two_entries(ch.ptr, this->public.sk.len, value.len,
 			this->public.sk.ptr, value.ptr);
-		CHECK_NZ(exchng(chunk_empty, this->comm, this->header_req));
-		CHECK_NZ(exchng(this->header_rsp, this->comm, ch));
+		CHECK_NZ(communicate(chunk_empty, this->header_req,
+			this->comm->stream,	&this->pqsdkd_ctx));
+		CHECK_NZ(communicate(this->header_rsp, ch, this->comm->stream,
+			&this->pqsdkd_ctx));
 		chunk_clear(&ch);
 
 		// get shared secret
@@ -266,7 +523,8 @@ METHOD(key_exchange_t, set_public_key, bool,
 		this->public.secret = chunk_alloc(sz);
 		CHECK_NZ(this->public.secret.ptr);
 
-		CHECK_NZ(exchng(this->public.secret, this->comm, chunk_empty));
+		CHECK_NZ(communicate(this->public.secret, chunk_empty,
+			this->comm->stream,	&this->pqsdkd_ctx));
 	}
 	this->public.has_secret = TRUE;
 	ret = TRUE;
@@ -315,8 +573,10 @@ struct pqsdkd_kem_t *pqsdkd_kem_create(key_exchange_method_t ike_meth_id)
 	struct private_pqsdkd_kem_t *this;
 	int pqsdkd_meth_id;
 	linked_list_t *conn_list;
+	int *message_exchange_to;
 
 	conn_list = lib->get(lib, "pqsdkd-connectors-list");
+	message_exchange_to = lib->get(lib, "message-exchange-timeout");
 	pqsdkd_meth_id = find_pqsdk_kem_id(ike_meth_id);
 
 	if (pqsdkd_meth_id == -1) {
@@ -326,6 +586,11 @@ struct pqsdkd_kem_t *pqsdkd_kem_create(key_exchange_method_t ike_meth_id)
 
 	if (!conn_list) {
 		DBG1(DBG_LIB, "Internal error: connection list not found");
+		return NULL;
+	}
+
+	if (!message_exchange_to) {
+		DBG1(DBG_LIB, "Message exchange must be a positivie number > 0");
 		return NULL;
 	}
 
@@ -346,15 +611,22 @@ struct pqsdkd_kem_t *pqsdkd_kem_create(key_exchange_method_t ike_meth_id)
 		.ike_meth_id = ike_meth_id,
 		.pqsdkd_meth_id = pqsdkd_meth_id,
 		.state = ACTION_CREATE,
+		.pqsdkd_ctx = {
+			.ex_cond = condvar_create(CONDVAR_TYPE_DEFAULT),
+			.ex_lock = mutex_create(MUTEX_TYPE_DEFAULT),
+			.rsp = NULL,
+			.req = NULL,
+			.msg_ex_to = *message_exchange_to,
+		},
 		.header_req = chunk_alloc(get_serialized_request_header_size()),
 		.header_rsp = chunk_alloc(get_serialized_response_header_size()),
 		.connection_list = conn_list,
 		.comm = comm_lock_next(conn_list),
 	);
+	this->pqsdkd_ctx.comm = this->comm;
 
-	// OZAPTF: implement waiting. How long to wait
 	if (!this->comm) {
-		DBG1(DBG_LIB, "Waiting for available connection\n");
+		DBG1(DBG_LIB, "No communication context available");
 		return NULL;
 	}
 

--- a/src/libstrongswan/plugins/pqsdk/pqsdkd/kem.h
+++ b/src/libstrongswan/plugins/pqsdk/pqsdkd/kem.h
@@ -56,6 +56,7 @@ struct pqsdkd_kem_t {
    * Shared secret
    */
   chunk_t secret;
+
   /**
    * Indicates wethar shared secret was generated and is
    * available to use.

--- a/src/libstrongswan/plugins/pqsdk/pqsdkd/pqsdkd_plugin.c
+++ b/src/libstrongswan/plugins/pqsdk/pqsdkd/pqsdkd_plugin.c
@@ -15,174 +15,175 @@
 
 #include <stdbool.h>
 
-#include <errno.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <unistd.h>
-
 #include <library.h>
 #include <plugins/plugin_feature.h>
-#include <threading/thread_value.h>
+#include <threading/mutex.h>
 #include <utils/debug.h>
 
-#include "pqsdkd_plugin.h"
+#include "comm.h"
 #include "kem.h"
+#include "pqsdkd_plugin.h"
 
-// max number of clients pqsdkd connection can accept
-#define MAX_CLIENTS 1
+extern linked_list_t *connection_list;
+extern mutex_t *connection_list_mutex;
 
 typedef struct private_pqsdkd_plugin_t private_pqsdkd_plugin_t;
 
 struct private_pqsdkd_plugin_t {
 
-    /**
-     * Public interface for the plugin. Always
-     * must go first.
-     */
-    pqsdkd_plugin_t public;
+	/**
+	 * Public interface for the plugin. Always
+	 * must go first.
+	 */
+	pqsdkd_plugin_t public;
 
-    /**
-     * Indicates weather PQSDK is initialized.
-     */
-    bool is_pqsdk_on;
+	/**
+	 * Indicates weather PQSDK is initialized.
+	 */
+	bool is_pqsdk_on;
 
-    /**
-     * PQSDKd communication context
-     */
-    comm_t comm;
+	/**
+	 * Number of connections to PQSDKd
+	 */
+	int pqsdkd_conn_n;
 };
 
 static int init_pqsdkd(private_pqsdkd_plugin_t *plugin) {
-    struct sockaddr_un sun = {0};
-    int ret;
+	if (plugin->is_pqsdk_on) {
+		// already initialized
+		goto end;
+	}
+	char *socket_path;
 
-    if (plugin->is_pqsdk_on) {
-        // already initialized
-        goto end;
-    }
+	plugin->pqsdkd_conn_n = lib->settings->get_int(lib->settings,
+		"%s.plugins.pqsdk-pqsdkd.pqsdkd_conn_n", 1, lib->ns);
 
-    plugin->comm.socket_path = lib->settings->get_str(lib->settings,
-        "%s.plugins.pqsdk-pqsdkd.socket_path", NULL, lib->ns);
-
-	if (!plugin->comm.socket_path) {
+	socket_path = lib->settings->get_str(lib->settings,
+		"%s.plugins.pqsdk-pqsdkd.socket_path", NULL, lib->ns);
+	if (!socket_path) {
 		DBG1(DBG_LIB, "Initialization failed PQSDKd socket not found. "
 			"Unable to connect to the PQSDKd daemon.");
 		goto end;
 	}
-	unlink(plugin->comm.socket_path);
 
-    ret = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (ret == -1) {
-        DBG1(DBG_LIB, "Can't open a socket FD=%d:\n%s", ret, strerror(errno));
-        goto end;
-    }
-    plugin->comm.fd = ret;
+	for (size_t i = 0; i<plugin->pqsdkd_conn_n; i++) {
+		comm_t *comm = (comm_t*)malloc(sizeof(*comm));
+		if (!comm) {
+			DBG1(DBG_LIB, "Memory allocation failed.");
+			goto end;
+		}
+		memset(comm, 0, sizeof(*comm));
 
-    sun.sun_family = AF_UNIX;
-    strncpy(sun.sun_path, plugin->comm.socket_path, sizeof(sun.sun_path) - 1);
-    ret = bind(plugin->comm.fd, (struct sockaddr *)&sun, sizeof(sun));
-    if (ret == -1) {
-        DBG1(DBG_LIB, "Can't bind to FD=%d:\n%s", plugin->comm.fd, strerror(errno));
-        goto end;
-    }
+		comm->stream = lib->streams->connect(
+			lib->streams, socket_path);
+		if (!comm->stream) {
+			DBG1(DBG_LIB, "Can't connect to PQSDKd.");
+			free(comm);
+			goto end;
+		}
 
-    if (listen(plugin->comm.fd, MAX_CLIENTS) == -1) {
-        DBG1(DBG_LIB, "Can't set FD=%d to listen:\n%s", plugin->comm.fd, strerror(errno));
-        goto end;
-    }
+		comm->id = i+1;
+		comm->socket_path = socket_path;
+		if (!comm_add(connection_list, comm)) {
+			free(comm);
+			DBG1(DBG_LIB, "PQSDKd requestor can't be initialized.");
+			goto end;
+		}
+	}
 
-    /**
-	 *  TODO: This may break strongswan initialization. Must be change once
-	 *        we switch daemon to work as a server.
-	 */
-    ret = accept(plugin->comm.fd, NULL, NULL);
-    if (ret == -1) {
-        DBG1(DBG_LIB, "Error accepting connection:\n%s", strerror(errno));
-        goto end;
-    }
-    plugin->comm.req = ret;
-    plugin->is_pqsdk_on = true;
+	plugin->is_pqsdk_on = true;
 
 end:
-    if (!plugin->is_pqsdk_on) {
-        if (plugin->comm.fd) {
-            close(plugin->comm.fd);
-        }
-        if (plugin->comm.req) {
-            close(plugin->comm.req);
-        }
-    }
-	// TODO: because of that plugin supports only one client
-    lib->set(lib, "pqsdkd-connector-main", &plugin->comm);
-    return (int)plugin->is_pqsdk_on;
+	if (plugin->is_pqsdk_on) {
+		// TODO: because of that plugin supports only one client
+		lib->set(lib, "pqsdkd-connectors-list", connection_list);
+	}
+
+	return (int)plugin->is_pqsdk_on;
 }
 
 METHOD(plugin_t, get_name, char*,
-    private_pqsdkd_plugin_t *this)
+	private_pqsdkd_plugin_t *this)
 {
-    return "pqsdk-pqsdkd";
+	return "pqsdk-pqsdkd";
 }
 
 METHOD(plugin_t, get_features, int,
-    private_pqsdkd_plugin_t *this, plugin_feature_t *features[])
+	private_pqsdkd_plugin_t *this, plugin_feature_t *features[])
 {
-    static plugin_feature_t f[] = {
-        PLUGIN_REGISTER(KE, pqsdkd_kem_create),
-            PLUGIN_PROVIDE(KE, KE_FRODO_SHAKE_L1),
-            PLUGIN_PROVIDE(KE, KE_FRODO_SHAKE_L3),
-            PLUGIN_PROVIDE(KE, KE_FRODO_SHAKE_L5),
-            PLUGIN_PROVIDE(KE, KE_KYBER_L1),
-            PLUGIN_PROVIDE(KE, KE_KYBER_L3),
-            PLUGIN_PROVIDE(KE, KE_KYBER_L5),
-            PLUGIN_PROVIDE(KE, KE_NTRU_HPS_L1),
-            PLUGIN_PROVIDE(KE, KE_NTRU_HRSS_L3),
-            PLUGIN_PROVIDE(KE, KE_SABER_L1),
-            PLUGIN_PROVIDE(KE, KE_SABER_L3),
-            PLUGIN_PROVIDE(KE, KE_SABER_L5),
-            PLUGIN_PROVIDE(KE, KE_RND5_5D_CCA_L1),
-            PLUGIN_PROVIDE(KE, KE_RND5_5D_CCA_L3),
-            PLUGIN_PROVIDE(KE, KE_RND5_5D_CCA_L5),
-    };
-    *features = f;
-    return countof(f);
+	static plugin_feature_t f[] = {
+		PLUGIN_REGISTER(KE, pqsdkd_kem_create),
+			PLUGIN_PROVIDE(KE, KE_FRODO_SHAKE_L1),
+			PLUGIN_PROVIDE(KE, KE_FRODO_SHAKE_L3),
+			PLUGIN_PROVIDE(KE, KE_FRODO_SHAKE_L5),
+			PLUGIN_PROVIDE(KE, KE_KYBER_L1),
+			PLUGIN_PROVIDE(KE, KE_KYBER_L3),
+			PLUGIN_PROVIDE(KE, KE_KYBER_L5),
+			PLUGIN_PROVIDE(KE, KE_NTRU_HPS_L1),
+			PLUGIN_PROVIDE(KE, KE_NTRU_HRSS_L3),
+			PLUGIN_PROVIDE(KE, KE_SABER_L1),
+			PLUGIN_PROVIDE(KE, KE_SABER_L3),
+			PLUGIN_PROVIDE(KE, KE_SABER_L5),
+			PLUGIN_PROVIDE(KE, KE_RND5_5D_CCA_L1),
+			PLUGIN_PROVIDE(KE, KE_RND5_5D_CCA_L3),
+			PLUGIN_PROVIDE(KE, KE_RND5_5D_CCA_L5),
+	};
+	*features = f;
+	return countof(f);
 }
 
 METHOD(plugin_t, destroy, void,
-    private_pqsdkd_plugin_t *this)
+	private_pqsdkd_plugin_t *this)
 {
-	close(this->comm.fd);
-	close(this->comm.req);
+	enumerator_t *it;
+	comm_t *el = NULL;
+
+	//this->comm.stream->destroy(this->comm.stream);
+	/*
 	if (this->comm.socket_path) {
 		unlink(this->comm.socket_path);
 		this->comm.socket_path = NULL;
 	}
-    free(this);
+	*/
+	if (connection_list) {
+		comm_clean_list(connection_list);
+		connection_list->destroy(connection_list);
+	}
+
+	if (connection_list_mutex) {
+		connection_list_mutex->destroy(connection_list_mutex);
+	}
+
+	free(this);
 }
 
 plugin_t *pqsdk_pqsdkd_plugin_create()
 {
-    private_pqsdkd_plugin_t *this;
+	private_pqsdkd_plugin_t *this;
 
-    INIT(this,
-        .public = {
-            .plugin = {
-                .get_name = _get_name,
-                .get_features = _get_features,
-                .destroy = _destroy,
-            },
-        },
-        .comm = {
-			.fd = 0,
-			.req =0,
-			.socket_path = 0
+	INIT(this,
+		.public = {
+			.plugin = {
+				.get_name = _get_name,
+				.get_features = _get_features,
+				.destroy = _destroy,
+			},
 		},
-    );
+	);
 
-    if (!init_pqsdkd(this)) {
-        DBG1(DBG_LIB, "PQSDK:PQSDKd initialization failed");
-        return NULL;
-    }
+	// Create connection_list and connection_list_mutex.
+	connection_list_mutex = mutex_create(MUTEX_TYPE_DEFAULT);
+	connection_list = linked_list_create();
 
-    return &this->public.plugin;
+	if (!connection_list_mutex || !connection_list) {
+		DBG1(DBG_LIB, "PQSDK:PQSDKd connection list initialization failed");
+		return NULL;
+	}
+
+	if (!init_pqsdkd(this)) {
+		DBG1(DBG_LIB, "PQSDK:PQSDKd initialization failed");
+		return NULL;
+	}
+
+	return &this->public.plugin;
 }

--- a/src/libstrongswan/plugins/pqsdk/pqsdkd/pqsdkd_plugin.h
+++ b/src/libstrongswan/plugins/pqsdk/pqsdkd/pqsdkd_plugin.h
@@ -28,7 +28,7 @@
 #include <stdbool.h>
 
 typedef struct pqsdkd_plugin_t pqsdkd_plugin_t;
-
+typedef struct comm_t comm_t;
 /**
  * The plugin adds support for post-quantum KEMs. The implementation
  * of KEMs is provided by PQShield's PQSDKd daemon.
@@ -40,5 +40,7 @@ struct pqsdkd_plugin_t {
    */
   plugin_t plugin;
 };
+
+job_requeue_t try_connect(comm_t *comm);
 
 #endif /** PQSDKD_PLUGIN_H_ @}*/

--- a/src/libstrongswan/plugins/pqsdk/pqsdkd/pqsdkd_plugin.h
+++ b/src/libstrongswan/plugins/pqsdk/pqsdkd/pqsdkd_plugin.h
@@ -25,6 +25,7 @@
 #define PQSDKD_PLUGIN_H_
 
 #include <plugins/plugin.h>
+#include <stdbool.h>
 
 typedef struct pqsdkd_plugin_t pqsdkd_plugin_t;
 
@@ -35,30 +36,9 @@ typedef struct pqsdkd_plugin_t pqsdkd_plugin_t;
 struct pqsdkd_plugin_t {
 
   /**
-   * implements plugin interface
+   * Implements plugin interface
    */
   plugin_t plugin;
 };
-
-/**
- * PQSDKd communication context. Stores file descriptor
- * for listener and the one returned by accept().
- */
-typedef struct comm_t {
-  /**
-   * Path to PQSDKd socket, read from configuration file.
-   */
-  const char* socket_path;
-
-  /**
-   * Listen socket.
-   */
-  int fd;
-
-  /**
-   * Acceptor socket used to send requests to PQSDKd
-   */
-  int req;
-} comm_t;
 
 #endif /** PQSDKD_PLUGIN_H_ @}*/

--- a/src/libstrongswan/plugins/pqsdk/tests/Makefile.am
+++ b/src/libstrongswan/plugins/pqsdk/tests/Makefile.am
@@ -2,20 +2,20 @@ TESTS = pqsdk_tests
 
 check_PROGRAMS = $(TESTS)
 
-pqsdk_tests_SOURCES =       \
-    pqsdk_tests.c           \
+pqsdk_tests_SOURCES = \
+    pqsdk_tests.c \
     pqsdk_tests_runner.c
 
 pqsdk_tests_CFLAGS = \
-    -I$(top_srcdir)/src/libstrongswan                               \
-    -I$(top_srcdir)/src/libstrongswan/tests                         \
+    -I$(top_srcdir)/src/libstrongswan \
+    -I$(top_srcdir)/src/libstrongswan/tests \
     -DPLUGINDIR=\""$(abs_top_builddir)/src/libstrongswan/plugins\"" \
-    -DPLUGINS=\""${s_plugins}\""                                    \
+    -DPLUGINS=\""${s_plugins}\"" \
     @COVERAGE_CFLAGS@
 
 pqsdk_tests_LDFLAGS = @COVERAGE_LDFLAGS@
-pqsdk_tests_LDADD =                                     \
-    $(top_builddir)/src/libstrongswan/libstrongswan.la  \
+pqsdk_tests_LDADD = \
+    $(top_builddir)/src/libstrongswan/libstrongswan.la \
     $(top_builddir)/src/libstrongswan/tests/libtest.la
 
 if USE_PQSDK_PQTLS

--- a/src/libstrongswan/plugins/pqsdk/tests/pqsdk_tests_runner.c
+++ b/src/libstrongswan/plugins/pqsdk/tests/pqsdk_tests_runner.c
@@ -29,6 +29,15 @@ static test_configuration_t tests[] = {
 };
 
 static bool test_runner_init(bool init) {
+	struct sigaction action;
+
+	if (!init) {
+		lib->processor->set_threads(lib->processor, 0);
+		lib->processor->cancel(lib->processor);
+		lib->plugins->unload(lib->plugins);
+		return TRUE;
+	}
+
 	lib->settings->set_str(lib->settings, "%s.plugins.pqsdk-pqsdkd.socket_path",
 		"unix:///tmp/pqsdkd.ut.sock", lib->ns);
 	/**
@@ -38,21 +47,30 @@ static bool test_runner_init(bool init) {
 	lib->settings->set_int(lib->settings, "%s.plugins.pqsdk-pqsdkd.pqsdkd_conn_n",
 		2, lib->ns);
 
-	if (init) {
-		char *plugins, *plugindir;
+	lib->settings->set_int(lib->settings, "%s.plugins.pqsdk-pqsdkd.reconnect_timeout",
+		10000, lib->ns);
 
-		plugins = lib->settings->get_str(lib->settings,
-										"tests.load", PLUGINS);
-		plugindir = lib->settings->get_str(lib->settings,
-										"tests.plugindir", PLUGINDIR);
-		plugin_loader_add_plugindirs(plugindir, plugins);
-		if (!lib->plugins->load(lib->plugins, plugins)) {
-			return FALSE;
-		}
-	} else {
-		lib->processor->set_threads(lib->processor, 0);
-		lib->processor->cancel(lib->processor);
-		lib->plugins->unload(lib->plugins);
+	char *plugins, *plugindir;
+
+	plugins = lib->settings->get_str(lib->settings,
+		"tests.load", PLUGINS);
+	plugindir = lib->settings->get_str(lib->settings,
+		"tests.plugindir", PLUGINDIR);
+	dbg_default_set_level(1);
+
+	/**
+	 * Ignore sigpipe. Needed in case, pqsdkd has crashed
+	 * but client is still trying to write. No changes in
+	 * Charon are needed as this is already implemented
+	 * there.
+	 */
+	action.sa_handler = SIG_IGN;
+	sigaction(SIGPIPE, &action, NULL);
+	pthread_sigmask(SIG_SETMASK, &action.sa_mask, NULL);
+
+	plugin_loader_add_plugindirs(plugindir, plugins);
+	if (!lib->plugins->load(lib->plugins, plugins)) {
+		return FALSE;
 	}
 	return TRUE;
 }

--- a/src/libstrongswan/plugins/pqsdk/tests/pqsdk_tests_runner.c
+++ b/src/libstrongswan/plugins/pqsdk/tests/pqsdk_tests_runner.c
@@ -30,7 +30,14 @@ static test_configuration_t tests[] = {
 
 static bool test_runner_init(bool init) {
 	lib->settings->set_str(lib->settings, "%s.plugins.pqsdk-pqsdkd.socket_path",
-		"/tmp/pqsdkd.ut.sock", lib->ns);
+		"unix:///tmp/pqsdkd.ut.sock", lib->ns);
+	/**
+	 * Min 2 connections as we have tests which create initiator & responders at
+	 * the same time.
+	 */
+	lib->settings->set_int(lib->settings, "%s.plugins.pqsdk-pqsdkd.pqsdkd_conn_n",
+		2, lib->ns);
+
 	if (init) {
 		char *plugins, *plugindir;
 


### PR DESCRIPTION
It introduces two changes:

1.

```
    Switch PQSDKd plugin from server to client mode
    
    In previous design the PQSDK:PQSDKd plugin was working
    as a server, which caused number of problems. This patch
    changes it and PQSDK:PQSDKd plugin is a client that connects
    to PQSDKd.
    
    In order to do that I've added structure called comm_t with
    supporting functions. Structure represents communication
    context which stores data that are needed to connect a
    socket and perform data exchange. There can be multiple
    communication sockets (2 by default), which means that there
    PQSDK:PQSDKD will open 2 connections to PQSDKd. It is safe
    to use both connections in parralel, which makes data exchange
    faster in case multiple clients want to use PQSDKD to perform
    post-quantum operation.
    
    Also, plugin uses now stream_manager facility implemented in
    strongSwan instead of dealing with raw sockets manually.
```

2.
```
    Use asynchornous I/O to communicate with PQSDKD
    
    In previous version the plugin used blocking calls to perform
    read/write. This patch switches configuration of a socket from
    from blocking to unblocking by calling read() and write() instead
    of read_all() and write_all(). Patch uses on_read and on_write
    callbacks from stream_t which are called once select() signals
    that it is ready to read or write.
    
    Also, once connection with PQSDKD is dropped, plugin will find
    it out and reconnect automatically without restarting as soon
    as PQSDKD is available again.

```